### PR TITLE
Critical Fix for Timestamps

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "@loskir/styled-qr-code-node": "^1.5.1",
     "@t3-oss/env-nextjs": "^0.7.1",
     "bcryptjs": "^2.4.3",
+    "date-fns": "^3.2.0",
     "mongoose": "^8.0.3",
     "next": "14.0.4",
     "next-auth": "^4.24.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,9 @@ importers:
       bcryptjs:
         specifier: ^2.4.3
         version: 2.4.3
+      date-fns:
+        specifier: ^3.2.0
+        version: 3.2.0
       mongoose:
         specifier: ^8.0.3
         version: 8.0.3
@@ -2461,6 +2464,10 @@ packages:
   /damerau-levenshtein@1.0.8:
     resolution: {integrity: sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==}
     dev: true
+
+  /date-fns@3.2.0:
+    resolution: {integrity: sha512-E4KWKavANzeuusPi0jUjpuI22SURAznGkx7eZV+4i6x2A+IZxAMcajgkvuDAU1bg40+xuhW1zRdVIIM/4khuIg==}
+    dev: false
 
   /debug@3.2.7:
     resolution: {integrity: sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==}

--- a/src/app/admin/scan/page.tsx
+++ b/src/app/admin/scan/page.tsx
@@ -1,12 +1,12 @@
 'use client';
 
+import { format } from 'date-fns/format';
 import { Html5Qrcode } from 'html5-qrcode';
 import { useRouter } from 'next/navigation';
 import { useEffect, useRef, useState } from 'react';
 import { FaCamera, FaTimes } from 'react-icons/fa';
 
 import { Button } from '@/components/Button';
-import { generateDateTimestamp } from '@/utils';
 
 export default function Scan() {
   const qrcodeRegionId = 'reader';
@@ -24,7 +24,10 @@ export default function Scan() {
 
     const qrCodeSuccessCallback = (decodedText: string) => {
       router.push(
-        `/admin/services?code=${decodedText}&date=${generateDateTimestamp()}`,
+        `/admin/services?code=${decodedText}&date=${format(
+          new Date(),
+          'yyyy-MM-dd',
+        )}`,
       );
       setShowScanner(false);
       if (html5QrCode.getState() === 2) html5QrCode.clear();

--- a/src/app/api/participant/seed/route.ts
+++ b/src/app/api/participant/seed/route.ts
@@ -1,12 +1,12 @@
 import { faker } from '@faker-js/faker';
 import { QRCodeCanvas } from '@loskir/styled-qr-code-node';
+import { format } from 'date-fns/format';
 import { NextRequest, NextResponse } from 'next/server';
 
 import { connectDB } from '@/db/config';
 import Participant from '@/db/models/participant';
 import {
   generateAvailableServices,
-  generateDateTimestamp,
   generateQRCodeOptions,
   verifyRequest,
   type ServicesByDate,
@@ -40,8 +40,7 @@ export async function POST(request: NextRequest) {
       for (let numServices = 0; numServices != maxNumServices; numServices++) {
         mockServices.push(faker.commerce.productName());
       }
-      mockServicesByDate[generateDateTimestamp(new Date(currentDate))] =
-        mockServices;
+      mockServicesByDate[format(currentDate, 'yyyy-MM-dd')] = mockServices;
       currentDate.setUTCDate(currentDate.getUTCDate() + dateStep);
     }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -79,14 +79,6 @@ export const getAvailableServicesByDate = (
   return availableServices;
 };
 
-export const generateDateTimestamp = (date = new Date()) => {
-  const month = date.getUTCMonth() + 1;
-
-  return `${date.getFullYear()}-${
-    month.toString().length === 2 ? month : `0${month}`
-  }-${date.getUTCDate()}`;
-};
-
 export const verifyRequest = (request: NextRequest) => {
   if (!request.headers.has('ds3-secret')) {
     return {


### PR DESCRIPTION
# Description

<!-- Please include a summary of the change -->

When creating generating timestamps after 6 PM, the date will be off by one day

Relevant GitHub Issues that will be fixed are

## Type of change

<!-- Select all options that are relevant. -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
      not work as expected)
- [ ] This change requires a documentation update
- [ ] Chore (anything else)

## How Has This Been Tested?

<!-- Summary of tests conducted -->

- [ ] Responsiveness on various devices
- Desktop Browser
  - [ ] Apple Safari
  - [ ] Google Chrome
  - [ ] Microsoft Edge
  - [ ] Mozilla FireFox
- Mobile Browser
  - [ ] Apple Safari
  - [ ] Google Chrome
  - [ ] Microsoft Edge
  - [ ] Mozilla FireFox
- Other Tests:

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation

## PR Closure

- Use **Squash And Merge** to Close Pull Request
- Delete any branch after merging
